### PR TITLE
ci: cancel obsolete runs and gate native builds on cheap checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Classify changed files
@@ -62,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Check workflow script syntax
         run: |
@@ -80,10 +83,12 @@ jobs:
   # ===========================================
   frontend:
     needs: changes
-    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false')
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -115,10 +120,10 @@ jobs:
   build-macos:
     needs: [changes, workflow, frontend]
     if: >-
-      always() &&
+      ${{ !cancelled() &&
       needs.workflow.result == 'success' &&
       needs.frontend.result == 'success' &&
-      (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false')
+      (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false') }}
     strategy:
       matrix:
         include:
@@ -129,6 +134,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Select Swift 6 toolchain (Parakeet sidecar needs Xcode 16+)
         run: |
@@ -207,10 +214,10 @@ jobs:
   build-windows:
     needs: [changes, workflow, frontend]
     if: >-
-      always() &&
+      ${{ !cancelled() &&
       needs.workflow.result == 'success' &&
       needs.frontend.result == 'success' &&
-      (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false')
+      (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false') }}
     runs-on: windows-2022
     env:
       # Keep Windows paths short to avoid MSBuild/FileTracker failures on deep dependency trees.
@@ -218,6 +225,8 @@ jobs:
       VULKAN_RUNTIME_VERSION: 1.3.290.0
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,20 @@
 name: CI
 
+# A manual dispatch validates the selected ref with the full matrix.
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -97,14 +107,18 @@ jobs:
         run: pnpm typecheck
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm exec vitest run src
 
   # ===========================================
   # Build macOS (full build = catches all issues)
   # ===========================================
   build-macos:
-    needs: changes
-    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false')
+    needs: [changes, workflow, frontend]
+    if: >-
+      always() &&
+      needs.workflow.result == 'success' &&
+      needs.frontend.result == 'success' &&
+      (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false')
     strategy:
       matrix:
         include:
@@ -191,8 +205,12 @@ jobs:
   # Build Windows (CPU-safe app + Vulkan sidecar)
   # ===========================================
   build-windows:
-    needs: changes
-    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false')
+    needs: [changes, workflow, frontend]
+    if: >-
+      always() &&
+      needs.workflow.result == 'success' &&
+      needs.frontend.result == 'success' &&
+      (needs.changes.result != 'success' || needs.changes.outputs.application_required != 'false')
     runs-on: windows-2022
     env:
       # Keep Windows paths short to avoid MSBuild/FileTracker failures on deep dependency trees.

--- a/.github/workflows/store-msix.yml
+++ b/.github/workflows/store-msix.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/store-msix.yml'
-      - '.github/workflows/ci.yml'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'scripts/build-msix-store.ps1'

--- a/.github/workflows/store-msix.yml
+++ b/.github/workflows/store-msix.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/store-msix.yml'
+      - '.github/workflows/ci.yml'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'scripts/build-msix-store.ps1'
@@ -19,9 +20,44 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  preflight:
+    name: Frontend preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22.19.0'
+          package-manager-cache: false
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.13.1 --activate
+          pnpm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: TypeScript check
+        run: pnpm typecheck
+
+      - name: Run tests
+        run: pnpm exec vitest run src
+
   build-store-msix:
     name: Build Store MSIX
+    needs: preflight
     runs-on: windows-latest
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/store-msix.yml
+++ b/.github/workflows/store-msix.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -71,6 +73,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/plans/062-ci-gating.md
+++ b/plans/062-ci-gating.md
@@ -1,6 +1,6 @@
 # Plan 062 — CI gating and compute policy
 
-Status: IN PROGRESS — claimed Codex 2026-09-06.
+Status: IMPLEMENTED — local workflow validation passed; remote checks pending.
 Base: main `4f9e497d`. Separate from PR #140 product/runtime fixes.
 
 ## Observed waste
@@ -39,3 +39,5 @@ Run workflow helper contract tests, JavaScript syntax checks and actionlint.
 Use the PR's workflow checks and a manual CI run to verify the updated job graph;
 confirm native jobs queue only after successful cheap checks. No product
 hardware smoke is claimed by CI policy validation.
+
+Local validation: all 18 workflow-helper tests pass; pinned actionlint 1.7.7 passes.

--- a/plans/062-ci-gating.md
+++ b/plans/062-ci-gating.md
@@ -41,3 +41,12 @@ confirm native jobs queue only after successful cheap checks. No product
 hardware smoke is claimed by CI policy validation.
 
 Local validation: all 18 workflow-helper tests pass; pinned actionlint 1.7.7 passes.
+
+## Review corrections — 2026-09-06
+
+Native and frontend conditions use `!cancelled()` rather than `always()` so
+superseded running jobs actually stop. GitHub re-evaluates job conditions during
+cancellation; unconditional `always()` can keep them alive. See the
+[workflow cancellation reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-cancellation).
+CI and Store checkouts also disable credential persistence before running
+repository code. Existing read-only workflow permissions remain intact.

--- a/plans/062-ci-gating.md
+++ b/plans/062-ci-gating.md
@@ -1,0 +1,41 @@
+# Plan 062 — CI gating and compute policy
+
+Status: IN PROGRESS — claimed Codex 2026-09-06.
+Base: main `4f9e497d`. Separate from PR #140 product/runtime fixes.
+
+## Observed waste
+
+PR source changes start frontend, two macOS builds, Windows, and Store MSIX
+concurrently. Failed cheap checks therefore burn native build minutes. CI and
+Store have no superseded-run cancellation. Releases are already manual.
+GitHub reports main is unprotected and has no rulesets (2026-09-06).
+
+## First shippable change
+
+- Cancel superseded CI/Store runs for the same PR/ref; keep workflows isolated
+  so CI never cancels release signing or Store and vice versa.
+- Gate macOS/Windows builds on successful workflow and frontend checks.
+- Give Store its own cheap frontend prerequisite before Windows provisioning.
+- Keep conservative application classification and automatic full native
+  validation for application changes.
+- Add workflow_dispatch to CI for an explicit full run of a chosen revision.
+- Do not change release triggers, signing, updater manifests, artifacts, or
+  runner provider. No Depot account/billing changes.
+
+## Follow-up gate before manual-only native validation
+
+Automatic native checks cannot be removed until main requires trustworthy
+validation of the current PR head/base. A persisted label or an old green run
+is insufficient. Use explicit maintainer dispatch, immutable checkout identity,
+fail-closed current-head/base verification and required checks with strict
+base currency. Test stale-head, changed-base, fork permissions and failed/
+canceled jobs before activating the policy. Preserve existing protection fields
+if configuring enforcement. Depot eligibility and measured speed/cost remain
+separate from this correctness gate.
+
+## Validation
+
+Run workflow helper contract tests, JavaScript syntax checks and actionlint.
+Use the PR's workflow checks and a manual CI run to verify the updated job graph;
+confirm native jobs queue only after successful cheap checks. No product
+hardware smoke is claimed by CI policy validation.

--- a/plans/062-ci-gating.md
+++ b/plans/062-ci-gating.md
@@ -50,3 +50,13 @@ cancellation; unconditional `always()` can keep them alive. See the
 [workflow cancellation reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-cancellation).
 CI and Store checkouts also disable credential persistence before running
 repository code. Existing read-only workflow permissions remain intact.
+
+The first corrected manual run (34004045086) stopped native jobs when frontend
+preflight caught main's existing dialog-close test failure. The dialog had
+already unmounted, contradicting the test's assumption that it must remain
+mounted with data-closed. Applied the same test-only correction as PR #140:
+wait for the dialog to disappear and verify persisted selection by reopening.
+No product code is pulled into this CI change.
+
+Removed CI-only YAML edits from Store triggers: the Store workflow owns its
+preflight and does not consume ci.yml, so unrelated CI edits should stay cheap.

--- a/plans/README.md
+++ b/plans/README.md
@@ -59,6 +59,13 @@ Verification commands used across all plans: `pnpm typecheck`, `pnpm lint`,
 | 058  | Media pause v2 — upgrade existing MediaPauseController to VoiceInk-grade (macOS perl MediaRemote bridge + enigo CGEvent key + resume delay + mute fallback; Windows session ledger + Store manifest capability) | P1 | M | — | IN PROGRESS — claimed Main 2026-08-21; macOS action layer landed + live-verified (MediaRemote pause→resume round trip confirmed in dev-app log 12:48; mute fallback exercised live via CoreAudio test binary). Remaining: resume-delay setting, perl-bridge fallback if JXA ever breaks, Windows session-ledger verification + MSIX \`globalMediaControl\` |
 | 059  | No-speech gate — pre-engine reject on strong absence evidence, all STT paths; kills hallucinate-and-polish | P0 | S | — | CODE COMPLETE — beta.8 candidate on `fix/no-speech-transient-windows`: calibrated quiet-silence gate plus fixed 5ms evidence windows for callback-size-independent transient rejection; deliberate punctuation preserved; two-wave adversarial review clear; 1395 backend tests + clippy `-D warnings` green. Packaged macOS/Windows smoke pending in `SMOKE.md`; Phase 2 engine-neutral neural VAD remains planned. |
 
+## Plan 062 — CI gating and compute policy
+
+IN PROGRESS — claimed Codex 2026-09-06 on `agent/062-ci-gating`, based on
+main `4f9e497d`. First ship cancellation and cheap-check prerequisites without
+weakening native validation; manual-only native builds require an enforced
+current-revision merge gate. See `062-ci-gating.md`.
+
 ## Code-done, awaiting batched manual smoke (`plans/SMOKE.md`)
 
 | Plan | Title | Code landed | Status |

--- a/src/components/sections/__tests__/EnhancementsSection.test.tsx
+++ b/src/components/sections/__tests__/EnhancementsSection.test.tsx
@@ -601,10 +601,15 @@ describe("EnhancementsSection", () => {
     expect(within(providersPanel).getByRole("tab", { name: "Cloud API" })).toBeInTheDocument();
 
     await user.click(within(providersPanel).getByRole("button", { name: /close/i }));
-    // jsdom never finishes the exit animation, so assert the closed state
-    // instead of unmount.
-    expect(screen.getByRole("dialog")).toHaveAttribute("data-closed");
+    // Closing may already unmount the dialog; assert the user-visible result.
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     expect(launcher).toHaveTextContent("OpenAI · GPT-5 Mini");
+    expect(launcher).toHaveTextContent("Active");
+    await user.click(launcher);
+    const reopenedPanel = await screen.findByRole("dialog");
+    expect(within(reopenedPanel).getByRole("combobox", { name: "Model for OpenAI" })).toHaveValue(
+      "GPT-5 Mini",
+    );
   });
 
   it("does not expand then collapse while configured settings load", async () => {


### PR DESCRIPTION
## Changes

Native CI and Store builds currently start before cheap checks finish and keep running after a newer revision arrives. Cancel superseded runs for the same PR/ref with cancellation-aware job conditions, and require successful frontend checks before native compute starts. macOS/Windows CI also waits for workflow validation. CI/Store checkouts do not persist GitHub credentials before executing repository code.

Add a manual full CI entry point for the selected ref. Keep automatic native validation for application changes, the conservative classifier fallback, and all release/signing/updater workflows unchanged.

This is the first slice of plan 062. Main currently has no merge protection. Switching native validation to manual-only is intentionally deferred until a required current-head/base gate is implemented and verified; skipped jobs must not become a path to merging unvalidated code. Depot is unchanged.

## Validation

- All 18 workflow-helper contract tests passed locally.
- Pinned actionlint 1.7.7 passed.
- Independent review cleared the job dependencies, manual-dispatch fallback, docs fast path and concurrency grouping.
- The earlier manual run exposed main’s stale dialog-close test assumption and correctly prevented native jobs from starting. The test now waits for closing to settle and verifies selection after reopening; no product code changed.
- All 666 frontend tests, typecheck and lint pass on this branch.
- Current head `96a079f5`: [full CI](https://github.com/moinulmoin/voicetypr/actions/runs/34004527354) passed frontend, workflow checks, macOS ARM64/Intel, and Windows. [Store MSIX](https://github.com/moinulmoin/voicetypr/actions/runs/34004527257) passed.
- Codex review completed for this head; CodeRabbit reported no actionable comments.

Separate from PR #140; based on main `4f9e497d`. No product code or release artifact contract changed.
